### PR TITLE
Widen StaticArrays.jl dependency compatibility to [0.9, 1.1).

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-StaticArrays = "^0.9, ^0.10"
+StaticArrays = "0.9 - 1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Widen the StaticArrays.jl dependency compatibility to [0.9 - 1.1).