### PR TITLE
Fix compatibility with Julia 1.13+ memhash removal

### DIFF
--- a/src/StrFs.jl
+++ b/src/StrFs.jl
@@ -38,11 +38,13 @@ end
 show(io::IO, str::StrF) = show(io, String(str))
 
 # this implementation is a modified copy from base/hashing2.jl
-function hash(str::StrF, h::UInt)
-    h += Base.memhash_seed
-    # note: use pointer(s) here (see #6058).
-    ccall(Base.memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32),
-          Base.cconvert(Ptr{UInt8}, str.bytes), sizeof(str), h % UInt32) + h
+if isdefined(Base, :memhash)
+    function hash(str::StrF, h::UInt)
+        h += Base.memhash_seed
+        # note: use pointer(s) here (see #6058).
+        ccall(Base.memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32),
+              Base.cconvert(Ptr{UInt8}, str.bytes), sizeof(str), h % UInt32) + h
+    end
 end
 
 promote_rule(::Type{String}, ::Type{StrF{S}}) where S = String
@@ -50,6 +52,8 @@ promote_rule(::Type{String}, ::Type{StrF{S}}) where S = String
 promote_rule(::Type{StrF{A}}, ::Type{StrF{B}}) where {A,B} = StrF{max(A,B)}
 
 codeunit(::StrF{S}) where S = UInt8
+
+codeunit(str::StrF{S}, i::Int) where S = str.bytes[i]
 
 function sizeof(str::StrF{S}) where S
     nul = findfirst(isequal(0x00), str.bytes)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,3 +98,12 @@ end
     @test Base.IteratorSize(S) ≡ Base.IteratorSize(String)
     @test Base.IteratorEltype(S) ≡ Base.IteratorEltype(S)
 end
+
+@testset "codeunit" begin
+    s = "hello"
+    strf = StrF{10}(s)
+    @test codeunit(strf) == UInt8
+    for i in 1:sizeof(s)
+        @test codeunit(strf, i) == codeunit(s, i)
+    end
+end


### PR DESCRIPTION
Remove hash method definition when Base.memhash is not available.
On Julia 1.13+, these AbstractString types will use the default
AbstractString hash implementation which is now efficient and
zero-copy based on codeunit/iterate.

For Julia <1.13, continue using the memhash-based implementation
for compatibility.

Related to JuliaLang/julia#59697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
